### PR TITLE
Updated value of @context to be either a URI  string or an object

### DIFF
--- a/json_schema.json
+++ b/json_schema.json
@@ -489,9 +489,7 @@
     }
   },
   "properties": {
-    "@context": {
-      "type": "string"
-    },
+    "@context": {"anyOf":[{"type":"string","format": "uri"},{"type":"object"}]} ,
     "isA": {
       "type": "string",
       "pattern":  "^EPCISDocument$"


### PR DESCRIPTION
Hi Danny,

We need to support either an @context as an inline data object or as a remotely referenced resource (via its URI)

Please consider this pull request.  If you're happy with this, please make the update.
You should have just received a request to join https://github.com/gs1/EPCIS with editing / write access.  I'll update the version in there to align with your latest version + this pull request.
If you know better than I do how to replace the history of that file in the github.com/gs1/EPCIS/JSON repository, feel free  to do so.  I'm  certainly not intending to  take credit for the work you did.  We just needed to make the file available for sharing with the WG so that they could test the JSON validation.  Sorry  that I accidentally used an old version.