### PR TITLE
creationDate --> created ,  schemaVersion : string

### DIFF
--- a/json_schema.json
+++ b/json_schema.json
@@ -495,9 +495,9 @@
       "pattern":  "^EPCISDocument$"
     },
     "schemaVersion": {
-      "type": "number"
+      "type": "string"
     },
-    "creationDate": {
+    "created": {
       "type": "string",
       "format": "date-time"
     },
@@ -548,5 +548,5 @@
       "required": [ "eventList" ]
     }
   },
-  "required": [ "schemaVersion", "creationDate", "epcisBody" ]
+  "required": [ "schemaVersion", "created", "epcisBody" ]
 }


### PR DESCRIPTION
Hi Danny,

Another pull request needed so that it validates against the examples - though still some remaining problems with other examples.

Changed creationDate to created (align with the  JSON/JSON-LD examples and dcterms:created)
Changed schemaVersion to expect a string, not a  number.   Could be e.g. 2.0.1, which is a string, not a  number